### PR TITLE
Upgrade to latest Spring version

### DIFF
--- a/01-Authorization-MVC/build.gradle
+++ b/01-Authorization-MVC/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 plugins {
     id 'java'
     id 'com.gradle.build-scan' version '2.0.2'
-    id 'org.springframework.boot' version '2.1.6.RELEASE'
-    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
+    id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id "io.freefair.lombok" version "3.7.5"
 }
 
@@ -27,7 +27,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.security:spring-security-config'
 
-    testImplementation 'org.springframework.security:spring-security-test:5.1.5.RELEASE'
+    testImplementation 'org.springframework.security:spring-security-test:5.2.1.RELEASE'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 }

--- a/01-Authorization-MVC/src/main/java/com/auth0/example/security/SecurityConfig.java
+++ b/01-Authorization-MVC/src/main/java/com/auth0/example/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         indeed intended for our app. Adding our own validator is easy to do:
         */
 
-        NimbusJwtDecoderJwkSupport jwtDecoder = (NimbusJwtDecoderJwkSupport)
+        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder)
                 JwtDecoders.fromOidcIssuerLocation(issuer);
 
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(audience);

--- a/01-Authorization-WebFlux/build.gradle
+++ b/01-Authorization-WebFlux/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 plugins {
     id 'java'
     id 'com.gradle.build-scan' version '2.0.2'
-    id 'org.springframework.boot' version '2.1.6.RELEASE'
-    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
+    id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id "io.freefair.lombok" version "3.7.5"
 }
 


### PR DESCRIPTION
## Changes

Updates to the latest version of Spring Boot, and use `NimbusJwtDecoder` instead of the now-deprecated `NimbusJwtDecoderJwkSupport`.

Quickstart article change here: https://github.com/auth0/docs/pull/8686