### PR TITLE
[SDK-1987] Add CORS config to sample

### DIFF
--- a/01-Authorization-MVC/src/main/java/com/auth0/example/security/SecurityConfig.java
+++ b/01-Authorization-MVC/src/main/java/com/auth0/example/security/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .mvcMatchers("/api/public").permitAll()
                 .mvcMatchers("/api/private").authenticated()
                 .mvcMatchers("/api/private-scoped").hasAuthority("SCOPE_read:messages")
-                .and()
-                .oauth2ResourceServer().jwt();
+                .and().cors()
+                .and().oauth2ResourceServer().jwt();
     }
 
     @Bean

--- a/01-Authorization-MVC/src/main/java/com/auth0/example/web/APIController.java
+++ b/01-Authorization-MVC/src/main/java/com/auth0/example/web/APIController.java
@@ -2,6 +2,7 @@ package com.auth0.example.web;
 
 import com.auth0.example.model.Message;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(path = "api", produces = MediaType.APPLICATION_JSON_VALUE)
+// For simplicity of this sample, allow all origins. Real applications should configure CORS for their use case.
+@CrossOrigin(origins = "*")
 public class APIController {
 
     @GetMapping(value = "/public")

--- a/01-Authorization-WebFlux/src/main/java/com/auth0/example/security/SecurityConfig.java
+++ b/01-Authorization-WebFlux/src/main/java/com/auth0/example/security/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig {
                 .pathMatchers("/api/public").permitAll()
                 .pathMatchers("/api/private").authenticated()
                 .pathMatchers("/api/private-scoped").hasAuthority("SCOPE_read:messages")
-                .and()
-                .oauth2ResourceServer()
+                .and().cors()
+                .and().oauth2ResourceServer()
                 .jwt().and().and().build();
     }
 

--- a/01-Authorization-WebFlux/src/main/java/com/auth0/example/web/APIController.java
+++ b/01-Authorization-WebFlux/src/main/java/com/auth0/example/web/APIController.java
@@ -2,6 +2,7 @@ package com.auth0.example.web;
 
 import com.auth0.example.model.Message;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +14,8 @@ import reactor.core.publisher.Mono;
  */
 @RestController
 @RequestMapping(path = "api", produces = MediaType.APPLICATION_JSON_VALUE)
+// For simplicity of this sample, allow all origins. Real applications should configure CORS for their use case.
+@CrossOrigin("*")
 public class APIController {
 
     @GetMapping(value = "/public")


### PR DESCRIPTION
Although there is no client application associated with this sample (the associated Quickstart just demonstrates it using cURL or another REST client), developers using it as a basis for an API to be called by a client application will likely run into CORS issue. This change simple configures CORS for all example endpoints to accept requests from any origin.