### PR TITLE
Simplify Spring Dependencies

### DIFF
--- a/01-Authorization-MVC/build.gradle
+++ b/01-Authorization-MVC/build.gradle
@@ -20,11 +20,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.security:spring-security-oauth2-resource-server'
-    implementation 'org.springframework.security:spring-security-oauth2-jose'
-    implementation 'org.springframework.security:spring-security-config'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/01-Authorization-WebFlux/build.gradle
+++ b/01-Authorization-WebFlux/build.gradle
@@ -21,8 +21,5 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.security:spring-security-config'
-    implementation 'org.springframework.security:spring-security-oauth2-resource-server'
-    implementation 'org.springframework.security:spring-security-oauth2-jose'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 }


### PR DESCRIPTION
This change replaces several spring security dependencies with a single starter dependency, `spring-boot-starter-oauth2-resource-server`.

https://github.com/auth0/docs/pull/9827 accompanies this change.