### PR TITLE
Update to Spring Boot 2.5.12

### DIFF
--- a/01-Authorization-MVC/build.gradle
+++ b/01-Authorization-MVC/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.5.12'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 

--- a/01-Authorization-WebFlux/build.gradle
+++ b/01-Authorization-WebFlux/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.5.12'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 


### PR DESCRIPTION
Updates to Spring version 2.5.12 and Gradle 7.4.2.

Addresses [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965).

A separate PR will be made to update the corresponding Quickstart.